### PR TITLE
Fix map init checking

### DIFF
--- a/can-validate/map/validate/validate.js
+++ b/can-validate/map/validate/validate.js
@@ -75,10 +75,11 @@ proto.__set = function (prop, value, current, success, error) {
 		validateOpts = getPropDefineBehavior("validate", prop, this.define),
 		processedValidateOptions = can.extend({},defaultValidationOpts,validateOpts),
 		defaultValue = getPropDefineBehavior("value", prop, this.define),
-		propIniting = typeof current === 'undefined' && (defaultValue === value || typeof value === 'undefined'),
+		propIniting = (this._init && this._init === 1) || false,
 		errors;
 
-	// If validation options set, run validation
+	// If validate opts are set and not initing, validate properties
+	// If validate opts are set and initing, validate properties only if validateOnInit is true
 	if((validateOpts && !propIniting) || (validateOpts && propIniting && processedValidateOptions.validateOnInit )  ) {
 
 		// run validation

--- a/can-validate/validate.test.js
+++ b/can-validate/validate.test.js
@@ -1,6 +1,8 @@
 /* jshint asi: false */
 import can from 'can';
-import 'can-validate';
+import 'validate.js';
+import 'can-validate/shims/validatejs.shim';
+import 'can-validate/can-validate';
 import 'steal-qunit';
 
 var testValues = {
@@ -19,10 +21,6 @@ var testOptions = {
 		numercality: true
 	}
 }
-
-test('default property values', function () {
-	equal(true, true, 'Yep');
-});
 
 test('once', function () {
 	var errors = can.validate.once(testValues.stringTest, testOptions.stringTest);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "can-validate",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "Validation plugin for CanJS that provides an abstraction layer to your validation library of choice (Shim may be required).",
 	"scripts": {
         "build": "node ./stealBuild.js",


### PR DESCRIPTION
I was doing all kinds of crazyness to check if the map was in "initialize" mode. All I had to do was check the `_init` property on the map.

Also cleaned up some tests.