### PR TITLE
Bugfix/18 handle carrot prefix in message

### DIFF
--- a/can-validate/map/validate/demo.html
+++ b/can-validate/map/validate/demo.html
@@ -79,7 +79,8 @@
 						validate: {
 							required: true,
 							numericality: {
-								greaterThan: 5
+								greaterThan: 5,
+								message: '^This is a custom message! Hi!'
 							},
 							validateOnInit: true
 						}

--- a/can-validate/shims/validatejs.shim.js
+++ b/can-validate/shims/validatejs.shim.js
@@ -52,14 +52,26 @@ var Shim = can.Construct.extend({
 	* a list of errors.
 	*/
 	once: function (value, options, name) {
-		var errors = validatejs.single(value, processOptions(options));
+		var errors = [];
+		var opts = [];
+		var validationOpts = []
 
-		// Add the name to the front of the error string
-		if (errors && name) {
-			for (var i = 0; i < errors.length; i++) {
-				// Attempt to prettyify the name in each error
-				errors[i] = can.capitalize(can.camelize(name)) + ' ' + errors[i];
-			}
+		// Check if name was passed, determines which validate method to use
+		if (name) {
+			// Since name exists, use the main validate method but just pass one
+			// property to it. Need to structure the objects it expects first.
+			opts[name] = value;
+			validationOpts[name] = processOptions(options);
+
+			// Use main validate method, gives us better handling of custom messages
+			// and key path name prepending.
+			errors = validatejs(opts, validationOpts);
+
+			// can.Map.define expects an array of strings, but main validate method
+			// returns an object.
+			errors = errors[name];
+		} else {
+			errors = validatejs.single(value, processOptions(options));
 		}
 
 		return errors;

--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
     "ignoreBrowser": true,
     "npmIgnore": [
       "documentjs",
-      "steal-qunit",
       "testee",
       "steal-tools",
       "xo"
     ],
+    "npmAlgorithm": "flat",
     "npmDependencies": [
       "steal-qunit"
     ],

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "can-validate",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Validation plugin for CanJS that provides an abstraction layer to your validation library of choice (Shim may be required).",
   "scripts": {
     "build": "node ./stealBuild.js",
     "develop": "http-server -p 3000 -c-1 -o",
-	  "lint": "xo",
+    "lint": "xo",
     "test": "xo && testee --browsers firefox can-validate.test.html",
     "prepublish": "npm run build",
     "publish": "git push origin --tags",
@@ -81,7 +81,7 @@
       "no-warning-comments": 0
     },
     "globals": [
-        "steal"
+      "steal"
     ],
     "ignore": [
       "node_modules/**",


### PR DESCRIPTION
Improved the demo to show how custom messages now respect the special handlers for customizing the message using variables and characters.

For example, before, if you wanted the custom message to be `You got an error`, you would get `PropName You got an error`. Adding the carrot like so, `^You got an error` would have no affect, although should result in `You got an error`.

The shim no longer handles adding property name to the error string. Instead we determine whether to use the main validate method, which handles the property name for us, or the `single` method. The `single` method does not handle the property name. 