### PR TITLE
Bugfix/fix error handling when errors empty

### DIFF
--- a/can-validate/shims/validatejs.shim.js
+++ b/can-validate/shims/validatejs.shim.js
@@ -69,7 +69,9 @@ var Shim = can.Construct.extend({
 
 			// can.Map.define expects an array of strings, but main validate method
 			// returns an object.
-			errors = errors[name];
+			if (errors) {
+				errors = errors[name];
+			}
 		} else {
 			errors = validatejs.single(value, processOptions(options));
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-validate",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Validation plugin for CanJS that provides an abstraction layer to your validation library of choice (Shim may be required).",
   "scripts": {
     "build": "node ./stealBuild.js",


### PR DESCRIPTION
When no validation errors are found, ValidateJS would return undefined which caused errors in the code.  Added handler to this situation.