### PR TITLE
Small refactor

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,23 @@
+{
+  "maxerr": 50,
+
+  "curly": true,
+  "eqeqeq": true,
+  "freeze": true,
+  "latedef": true,
+  "noarg": true,
+  "undef": true,
+  "unused": true,
+  "maxdepth": 4,
+  "boss": true,
+  "eqnull": true,
+  "evil": true,
+  "loopfunc": true,
+  "browser": true,
+  "node": true,
+  "esnext": true,
+
+  "globals": {
+    "QUnit": true
+  }
+}

--- a/can-validate.js
+++ b/can-validate.js
@@ -1,5 +1,4 @@
-var each = require('can-util/js/each/each');
-var isArray = require('can-util/js/is-array/is-array');
+var canReflect = require('can-reflect');
 
 var validate = {};
 
@@ -7,8 +6,8 @@ var helpers = {
 	'object': function (normalizedErrors) {
 		var errors = normalizedErrors.length > 0 ? {}: undefined;
 
-		each(normalizedErrors, function (error) {
-			each(error.related, function (related) {
+		canReflect.eachIndex(normalizedErrors, function (error) {
+			canReflect.eachIndex(error.related, function (related) {
 				if (!errors[related]) {
 					errors[related] = [];
 				}
@@ -19,7 +18,7 @@ var helpers = {
 	},
 	'flat': function (normalizedErrors) {
 		var errors = normalizedErrors.length > 0 ? []: undefined;
-		each(normalizedErrors, function (error) {
+		canReflect.eachIndex(normalizedErrors, function (error) {
 			errors.push(error.message);
 		});
 		return errors;
@@ -29,8 +28,8 @@ var helpers = {
 	},
 	'errors-object': function (normalizedErrors) {
 		var errors = normalizedErrors.length > 0 ? {}: undefined;
-		each(normalizedErrors, function (error) {
-			each(error.related, function (related) {
+		canReflect.eachIndex(normalizedErrors, function (error) {
+			canReflect.eachIndex(error.related, function (related) {
 				if (!errors[related]) {
 					errors[related] = [];
 				}
@@ -46,11 +45,11 @@ var parseErrorItem = function (rawErrors) {
 	if (typeof rawErrors === 'string') {
 		errors.push({message: rawErrors, related: ['*']});
 	}
-	if (typeof rawErrors === 'object' && !isArray(rawErrors)) {
+	if (typeof rawErrors === 'object' && !Array.isArray(rawErrors)) {
 		// Although related can be a string, internally, it is easier if it is
 		// always an array
 		if (rawErrors.related) {
-			if (!isArray(rawErrors.related)) {
+			if (!Array.isArray(rawErrors.related)) {
 				rawErrors.related = [rawErrors.related];
 			}
 		} else {
@@ -58,8 +57,8 @@ var parseErrorItem = function (rawErrors) {
 		}
 		errors.push(rawErrors);
 	}
-	if (isArray(rawErrors)) {
-		each(rawErrors, function (error) {
+	if (Array.isArray(rawErrors)) {
+		canReflect.eachIndex(rawErrors, function (error) {
 			[].push.apply(errors, parseErrorItem(error));
 		});
 	}
@@ -69,13 +68,16 @@ var parseErrorItem = function (rawErrors) {
 // Takes errors and normalizes them
 var normalizeErrors = function (rawErrors) {
 	var normalizedErrors = [];
-	if (typeof rawErrors === 'string' || (typeof rawErrors === 'object' && !isArray(rawErrors))) {
+  if (
+    typeof rawErrors === 'string' ||
+    (typeof rawErrors === 'object' && !Array.isArray(rawErrors))
+  ) {
 		// Only one error set, which we can assume was for a single property
 		rawErrors = [rawErrors];
 	}
-	each(rawErrors, function (error) {
-        [].push.apply(normalizedErrors, parseErrorItem(error));
-	});
+  canReflect.eachIndex(rawErrors, function (error) {
+    [].push.apply(normalizedErrors, parseErrorItem(error));
+  });
 
 	return normalizedErrors;
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "postversion": "git push --tags && git checkout master && git branch -D release && git push",
     "testee": "testee test.html --browsers firefox",
     "test": "npm run detect-cycle && npm run jshint && npm run testee",
-    "jshint": "jshint .",
+    "jshint": "jshint . --config",
     "release:pre": "npm version prerelease && npm run build && npm publish --tag=pre",
     "release:patch": "npm version patch && npm run build && npm publish",
     "release:minor": "npm version minor && npm run build && npm publish",
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/canjs/can-validate",
   "devDependencies": {
-    "bit-docs": "0.0.8-2",
+    "bit-docs": "0.0.8",
     "detect-cyclic-packages": "^1.1.0",
     "http-server": "^0.10.0",
     "jshint": "^2.9.4",
@@ -53,13 +53,11 @@
       "testee",
       "steal-tools"
     ],
-    "npmAlgorithm": "flat",
     "npmDependencies": [
       "steal-qunit"
-    ],
-    "transpiler": "babel"
+    ]
   },
   "dependencies": {
-    "can-util": "^3.9.0"
+    "can-reflect": "^1.11.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,5 @@
 var validate = require('can-validate');
 var QUnit = require('steal-qunit');
-var isEmptyObject = require('can-util/js/is-empty-object/is-empty-object');
 
 var requireString = 'is required';
 var numberString = 'must be a number';


### PR DESCRIPTION
- Use can-reflect instead of can-util
- Fix jshint setup, it needed a config file
- Remove unused import
- Use bit-docs 0.0.8 (instead of the prerelease)

There wasn't a lot to update here @justinbmeyer 